### PR TITLE
Fix #71 modify maven command based on existence of APPLITOOLS_API_KEY

### DIFF
--- a/run_locally.cmd
+++ b/run_locally.cmd
@@ -61,6 +61,9 @@ if %errorlevel%==1 (
     pause>nul
 )
 
+set cmdFileDirectory=%~dp0
+
+cd %cmdFileDirectory%
 call mvn clean
 
 echo:
@@ -71,7 +74,7 @@ echo ####                               ####
 echo #######################################
 echo:
 
-cd ui/js
+cd %cmdFileDirectory%ui\js
 call npm install
 call npm run build
 
@@ -83,11 +86,13 @@ echo ####                               ####
 echo #######################################
 echo:
 
-cd ../..
-
-call mvn install
-
-call mvn install -Dvisual.skip.test=true
+cd %cmdFileDirectory%
+if defined APPLITOOLS_API_KEY (
+    call mvn install
+) else (
+    echo Skipping visual checks because no applitools api key has been set. Assign a key to APPLITOOLS_API_KEY to run visual checks
+    call mvn install -Dvisual.skip.test=true
+)
 
 echo:
 echo ####### RESTFUL-BOOKER-PLATFORM #######
@@ -112,8 +117,7 @@ echo ####    RUNNING E2E CHECKS         ####
 echo ####                               ####
 echo #######################################
 
-cd end-to-end-tests
-
+cd %cmdFileDirectory%end-to-end-tests
 call mvn clean test
 
 echo:


### PR DESCRIPTION
As well as checking for the APPLITOOLS_API_KEY env variable this will also ensure commands are all run in relation to the directory that the cmd file resides in (This means you should be able to call it from anywhere and it will work out the correct paths).

Only tested on a Windows 10 machine (since that's all I have available at the moment) so you may want to sanity check it on a few other windows versions.

Tested using system environmental variables and user environmental variables