### PR TITLE
Fix: "The Bean Validation API is on the classpath but no implementati…

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -72,6 +72,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
…on could be found"

Currently, auth container fails on boot with the following error:
```
***************************
APPLICATION FAILED TO START
***************************

Description:

The Bean Validation API is on the classpath but no implementation could be found

Action:

Add an implementation, such as Hibernate Validator, to the classpath

2022-09-22 19:49:14.388  INFO 6 --- [main] c.a.api.AuthApplication                  : Starting AuthApplication v1.6.59772ab using Java 15.0.2 on 8250b45f3df5 with PID 6 (/usr/local/auth/restful-booker-platform-auth-1.6.59772ab-exec.jar started by root in /usr/local/auth)
2022-09-22 19:49:14.400  INFO 6 --- [main] c.a.api.AuthApplication                  : The following 1 profile is active: "prod"
2022-09-22 19:49:16.041  WARN 6 --- [main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'io.honeycomb.beeline.spring.autoconfig.BeelineConfig': Unsatisfied dependency expressed through field 'properties'; nested exception is org.springframework.boot.context.properties.ConfigurationPropertiesBindException: Error creating bean with name 'honeycomb.beeline-io.honeycomb.beeline.spring.autoconfig.BeelineProperties': Could not bind properties to 'BeelineProperties' : prefix=honeycomb.beeline, ignoreInvalidFields=false, ignoreUnknownFields=true; nested exception is javax.validation.NoProviderFoundException: Unable to create a Configuration, because no Jakarta Bean Validation provider could be found. Add a provider like Hibernate Validator (RI) to your classpath.
2022-09-22 19:49:16.065  INFO 6 --- [main] ConditionEvaluationReportLoggingListener :

Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2022-09-22 19:49:16.081 ERROR 6 --- [main] o.s.b.d.LoggingFailureAnalysisReporter   :
```

As per: https://stackoverflow.com/questions/48483120/the-bean-validation-api-is-on-the-classpath-but-no-implementation-could-be-foun, adding 
```
<dependency>
  <groupId>org.springframework.boot</groupId>
  <artifactId>spring-boot-starter-validation</artifactId>
</dependency>
```
Solves the issue.